### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/FreeCodeCampLondon/FCCLND.png?label=ready&title=Ready)](https://waffle.io/FreeCodeCampLondon/FCCLND)
 # FCC London Campers Web App
 
 [![Join the chat at https://gitter.im/artitudinale1/FCCLND](https://badges.gitter.im/FreeCodeCampLondon/FCCLND.svg)](https://gitter.im/FreeCodeCampLondon/FCCLND?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/FreeCodeCampLondon/FCCLND

This was requested by a real person (user chris-alexander) on waffle.io, we're not trying to spam you.
